### PR TITLE
Whitelist ngrok domain for testing

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Whitelist ngrok for ease of testing
+  config.hosts << /[a-z0-9]+\.ngrok\.io/
 end


### PR DESCRIPTION
Added `config.host` option to development.rb to whitelist ngrok